### PR TITLE
Change Branch Name To Run GH Workflow And Update Readme

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -6,7 +6,7 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches:
-      - main
+      - master
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 My personal website using [Hugo](https://gohugo.io/). I'm using the [Stack theme](https://stack.jimmycai.com/)
 
-My previous version was using Jekyll, but I hated installing random npm modules and dependencies to get it up and running. Also, I'm biased towards Golang, hence making the switch :smile
+My previous version was using Jekyll, but I hated installing random npm modules and dependencies to get it up and running. Also, I'm biased towards Golang, hence making the switch 😄


### PR DESCRIPTION
Our release branch is still `master` not `main`. Hence, changing it. Also, fixing the emoji on README.md